### PR TITLE
Add revertPayment method to PaymentService

### DIFF
--- a/src/main/java/com/app/vms/Service/PaymentService.java
+++ b/src/main/java/com/app/vms/Service/PaymentService.java
@@ -44,5 +44,23 @@ public class PaymentService {
         return "Invoice not found or already paid.";
     }
 
+    public String revertPayment(Long paymentId) {
+        Optional<Payment> paymentOpt = paymentRepository.findById(paymentId);
 
+        if (paymentOpt.isPresent()) {
+            Payment payment = paymentOpt.get();
+            Invoice invoice = payment.getInvoice();
+
+            paymentRepository.delete(payment);
+
+            if (invoice != null && invoice.isPaid()) {
+                invoice.setPaid(false);
+                invoiceRepository.save(invoice);
+            }
+
+            return "Payment reverted successfully for Payment ID: " + paymentId;
+        }
+
+        return "Payment not found.";
+    }
 }


### PR DESCRIPTION
Added a new method revertPayment in PaymentService to allow reverting a payment by its ID. This method deletes the specified payment and marks the associated invoice as unpaid if applicable. Useful for handling payment rollback scenarios or administrative corrections.